### PR TITLE
Added unit scaling for GLTF files

### DIFF
--- a/Gltf/src/org/bimserver/gltf/BinaryGltfSerializer.java
+++ b/Gltf/src/org/bimserver/gltf/BinaryGltfSerializer.java
@@ -147,8 +147,15 @@ public class BinaryGltfSerializer extends BinaryGltfBaseSerializer {
 		translationChildrenNode = OBJECT_MAPPER.createArrayNode();
 		translationNode.set("children", translationChildrenNode);
 		translationNode.set("translation", modelTranslation);
+
+		ArrayNode scaleNode = OBJECT_MAPPER.createArrayNode();
+		float scale = (float) (getProjectInfo().getMultiplierToMm() / 1000.f);
+		scaleNode.add(scale);
+		scaleNode.add(scale);
+		scaleNode.add(scale);
+		translationNode.set("scale", scaleNode);
+
 		ObjectNode rotationNode = OBJECT_MAPPER.createObjectNode();
-		
 		ArrayNode rotation = OBJECT_MAPPER.createArrayNode();
 		ArrayNode rotationChildrenNode = OBJECT_MAPPER.createArrayNode();
 		rotationChildrenNode.add("translationNode");
@@ -484,6 +491,7 @@ public class BinaryGltfSerializer extends BinaryGltfBaseSerializer {
 		float[] changes = new float[3];
 		for (int i=0; i<3; i++) {
 			changes[i] = (max[i] - min[i]) / 2.0f + min[i];
+			changes[i] *= (float) (getProjectInfo().getMultiplierToMm() / 1000.0f);
 		}
 		return changes;
 	}

--- a/Gltf/src/org/bimserver/gltf/BinaryGltfSerializer2.java
+++ b/Gltf/src/org/bimserver/gltf/BinaryGltfSerializer2.java
@@ -142,8 +142,15 @@ public class BinaryGltfSerializer2 extends BinaryGltfBaseSerializer {
 		translationChildrenNode = OBJECT_MAPPER.createArrayNode();
 		translationNode.set("children", translationChildrenNode);
 		translationNode.set("translation", modelTranslation);
+
+		ArrayNode scaleNode = OBJECT_MAPPER.createArrayNode();
+		float scale = (float) (getProjectInfo().getMultiplierToMm() / 1000.f);
+		scaleNode.add(scale);
+		scaleNode.add(scale);
+		scaleNode.add(scale);
+		translationNode.set("scale", scaleNode);
+
 		ObjectNode rotationNode = OBJECT_MAPPER.createObjectNode();
-		
 		ArrayNode rotation = OBJECT_MAPPER.createArrayNode();
 		ArrayNode rotationChildrenNode = OBJECT_MAPPER.createArrayNode();
 
@@ -380,6 +387,7 @@ public class BinaryGltfSerializer2 extends BinaryGltfBaseSerializer {
 		double[] changes = new double[3];
 		for (int i=0; i<3; i++) {
 			changes[i] = (max[i] - min[i]) / 2.0f + min[i];
+			changes[i] *= (float) (getProjectInfo().getMultiplierToMm() / 1000.0f);
 		}
 		return changes;
 	}


### PR DESCRIPTION
In this commit (aimed towards fixing issue #1359 in the BimServer repo), I added a scaleNode which applies a global scale to the .glb/.gltf model within BinaryGltfSerializer2.createModelNode() and BinaryGltfSerializer.createModelNode().  I also applied a unit multiplier to getOffsets() in both of these files to apply the correct translation when using different units.